### PR TITLE
Adding the ID and RECO SFs for electrons for UL17

### DIFF
--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -208,10 +208,10 @@
     "MUON_ID_RefTracks" :  "genTracks",
     "MUON_ID_RefTracks_LowPt" : "genTracks",
 
-    "Ele_ID_SF_FileName" : "flashgg/Systematics/data/combined_eleIDSFs_2017.json",
+    "Ele_ID_SF_FileName" : "flashgg/Systematics/data/combined_MVA_eleIDSFs_UL_2017.json",
     "Ele_ID_version" : "mvaEleID-Fall17-iso-V2-wp90",
 
-    "Ele_reco_SF_FileName" : "flashgg/Systematics/data/2017_reco-eff.json",
+    "Ele_reco_SF_FileName" : "flashgg/Systematics/data/2017_UL_reco-eff.json",
 
     "bTagSystematics" :
     {


### PR DESCRIPTION
Adding the ID and RECO SFs for electrons for UL17.
The Muon ID SFs are a regex somersault away [hopefully by Sunday, now that there is a night curfew in Saint-Genis of all places]