### PR TITLE
 Update with the UL17 Muon  ID, ISO and  Low Pt ID SFs

### DIFF
--- a/MetaData/data/MetaConditions/Era2017_legacy_v1.json
+++ b/MetaData/data/MetaConditions/Era2017_legacy_v1.json
@@ -201,11 +201,11 @@
     "MUON_ID" : "Medium",
     "MUON_ISO" : "LooseRel",
 
-    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ID.json",
-    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ID_lowPt.json",
-    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon2017_RunBCDEF_SF_ISO.json",
+    "MUON_ID_JSON_FileName" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ID.json",
+    "MUON_ID_JSON_FileName_LowPt" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ID_lowPt.json",
+    "MUON_ISO_JSON_FileName" : "flashgg/Systematics/data/Muon_UL2017_RunBCDEF_SF_ISO.json",
 
-    "MUON_ID_RefTracks" :  "genTracks",
+    "MUON_ID_RefTracks" :  "TrackerMuons",
     "MUON_ID_RefTracks_LowPt" : "genTracks",
 
     "Ele_ID_SF_FileName" : "flashgg/Systematics/data/combined_MVA_eleIDSFs_UL_2017.json",

--- a/Systematics/python/flashggMuonSystematics_cfi.py
+++ b/Systematics/python/flashggMuonSystematics_cfi.py
@@ -22,6 +22,8 @@ class MuonSF_JSONReader :
         format_bins = r'^(?P<VarName>.*):\[(?P<From>-?\d*.\d*),(?P<To>-?\d*.\d*)\]'
         minPt = 1000
         for eta_region in self.Info[sub_branch_name] :
+            if eta_region == 'binning':
+               continue
             for pt_region in self.Info[sub_branch_name][eta_region] :
                 pt_values = re.match( format_bins , pt_region , re.M|re.I )
                 if pt_values and len( pt_values.groups() ) == 3 :
@@ -44,6 +46,8 @@ class MuonSF_JSONReader :
 
 
         for eta_region in self.Info[sub_branch_name] :
+            if eta_region == 'binning':
+               continue
             eta_values = re.match( format_bins , eta_region , re.M|re.I )
             if eta_values and len( eta_values.groups() ) == 3 :
                 eta_from = float( eta_values.group("From") )


### PR DESCRIPTION
The original files for these three Muon SFs are from:
1) https://gitlab.cern.ch/cms-muonPOG/MuonReferenceEfficiencies/-/tree/master/EfficienciesStudies/UL2017/DEN_TrackerMuons/jsonfiles [ID and ISO]. Committed as Muon_UL2017_RunBCDEF_SF_ID.json and Muon_UL2017_RunBCDEF_SF_ISO.json
and 
2) https://gitlab.cern.ch/cms-muonPOG/MuonReferenceEfficiencies/-/tree/patch-4/%20UL2017_JPsi/%20DEN_TrackerMuons/jsonfiles [Low Pt ID] Committed as Muon_UL2017_RunBCDEF_SF_ID_lowPt.json

New w.r.t before in the files 1) :
    (i) Additional field "binning" in the JSONs at the same level as the eta bins
    (ii) Number of significant figures in the Eta bin bounds reduced to 1 from 2 earlier and also as in 2)
    (iii) The ID "names" are different end as "_TrackerMuons" instead of "_genTracks"

Solution adopted adds two line to ignore the "binning" field and edits the file in 2 to reduce the number
of significant figures in the eta bin bounds from 2 to 1 like in the files in 1)

